### PR TITLE
Improve differential extraction

### DIFF
--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/batch/ArgsChecker.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/batch/ArgsChecker.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 
@@ -33,7 +34,7 @@ public class ArgsChecker {
     private boolean withEncryption;
     private boolean isFileByFile;
     private boolean withDDI;
-    private LocalDateTime since;
+    private Instant since;
     private boolean addStates;
     private Integer batchSize;
     private Mode mode;
@@ -123,7 +124,7 @@ public class ArgsChecker {
     private void checkArgSince() {
         if(this.argSince != null){
             try {
-                this.since = LocalDateTime.parse(argSince);
+                this.since = Instant.parse(argSince);
             }catch (DateTimeParseException e){
                 log.error(e.toString());
                 throw new IllegalArgumentException("Invalid since argument ! : %s, should be YYYY-MM-DDThh:mm:ss");

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/client/GenesisClient.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/client/GenesisClient.java
@@ -104,11 +104,11 @@ public class GenesisClient {
 		return Optional.ofNullable(response.getBody()).orElseThrow(() -> new KraftwerkException(502,"Empty response body from Genesis API"));
 	}
 
-    public List<InterrogationId> getInterrogationIdsBetweenDates(String collectionInstrumentId, Instant start, Instant end) throws KraftwerkException {
-		String url = String.format("%s/interrogations/by-collection-instrument-and-between-datetime?collectionInstrumentId=%s&start=%s&end=%s",
+    public InterrogationBatchResponse getInterrogationBatchBetween(String collectionInstrumentId, Instant start, Instant end) throws KraftwerkException {
+		String url = String.format("%s/collection-instruments/%s/interrogations?since=%s&until=%s",
 				configProperties.getGenesisUrl(), collectionInstrumentId,start,end);
-		ResponseEntity<InterrogationId[]> response = makeApiCall(url,HttpMethod.GET,null,InterrogationId[].class);
-		return response.getBody() != null ? Arrays.asList(response.getBody()) : null;
+		ResponseEntity<InterrogationBatchResponse> response = makeApiCall(url,HttpMethod.GET,null,InterrogationBatchResponse.class);
+		return Optional.ofNullable(response.getBody()).orElseThrow(() -> new KraftwerkException(502,"Empty response body from Genesis API"));
 	}
 
 	public List<Mode> getModes(String campaignId) throws KraftwerkException {

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/client/GenesisClient.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/client/GenesisClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.insee.bpm.metadata.model.MetadataModel;
 import fr.insee.kraftwerk.api.configuration.ConfigProperties;
+import fr.insee.kraftwerk.api.dto.InterrogationBatchResponse;
 import fr.insee.kraftwerk.api.dto.LastJsonExtractionDate;
 import fr.insee.kraftwerk.core.data.model.InterrogationId;
 import fr.insee.kraftwerk.core.data.model.Mode;
@@ -22,10 +23,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class GenesisClient {
@@ -87,11 +90,18 @@ public class GenesisClient {
 		return response.getBody() != null ? Arrays.asList(response.getBody()) : null;
 	}
 
-	public List<InterrogationId> getInterrogationIdsFromDate(String questionnaireId, LocalDateTime since) throws KraftwerkException {
-		String url = String.format("%s/interrogations/by-questionnaire-and-since-datetime?questionnaireId=%s&since=%s",
-				configProperties.getGenesisUrl(), questionnaireId,since);
-		ResponseEntity<InterrogationId[]> response = makeApiCall(url,HttpMethod.GET,null,InterrogationId[].class);
-		return response.getBody() != null ? Arrays.asList(response.getBody()) : null;
+	public InterrogationBatchResponse getInterrogationBatchAll(String collectionInstrumentId) throws KraftwerkException {
+		String url = String.format("%s/collection-instruments/%s/interrogations/all",
+				configProperties.getGenesisUrl(), collectionInstrumentId);
+		ResponseEntity<InterrogationBatchResponse> response = makeApiCall(url,HttpMethod.GET,null,InterrogationBatchResponse.class);
+		return Optional.ofNullable(response.getBody()).orElseThrow(() -> new KraftwerkException(502,"Empty response body from Genesis API"));
+	}
+
+	public InterrogationBatchResponse getInterrogationBatchSince(String collectionInstrumentId, Instant since) throws KraftwerkException {
+		String url = String.format("%s/collection-instruments/%s/interrogations?since=%s",
+				configProperties.getGenesisUrl(), collectionInstrumentId, since);
+		ResponseEntity<InterrogationBatchResponse> response = makeApiCall(url,HttpMethod.GET,null,InterrogationBatchResponse.class);
+		return Optional.ofNullable(response.getBody()).orElseThrow(() -> new KraftwerkException(502,"Empty response body from Genesis API"));
 	}
 
     public List<InterrogationId> getInterrogationIdsBetweenDates(String collectionInstrumentId, LocalDateTime start, LocalDateTime end) throws KraftwerkException {
@@ -117,8 +127,11 @@ public class GenesisClient {
 		return modes;
 	}
 	
-	public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds) throws KraftwerkException {
+	public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds, Instant recordedBefore) throws KraftwerkException {
 		String url = String.format("%s/responses/%s", configProperties.getGenesisUrl(), collectionInstrumentId);
+		if (recordedBefore != null) {
+			url += "?recordedBefore=" + recordedBefore;
+		}
 		ResponseEntity<SurveyUnitUpdateLatest[]> response = makeApiCall(url,HttpMethod.POST,interrogationIds,SurveyUnitUpdateLatest[].class);
 		return response.getBody() != null ? Arrays.asList(response.getBody()) : null;
 	}
@@ -149,20 +162,20 @@ public class GenesisClient {
 		makeApiCall(url,HttpMethod.POST,metadataModel,null);
 	}
 
-	public void saveDateExtraction(String collectionInstrumentId, Mode mode) throws KraftwerkException {
-		String url = String.format("%s/extractions/json?collectionInstrumentId=%s",
+	public void saveDateExtraction(String collectionInstrumentId, Mode mode, LastJsonExtractionDate lastJsonExtractionDate) throws KraftwerkException {
+		String url = String.format("%s/collection-instruments/%s/extractions/json/last",
 				configProperties.getGenesisUrl(), collectionInstrumentId);
 		if (mode != null) {
-			url += "&mode=" + mode;
+			url += "?mode=" + mode;
 		}
-		makeApiCall(url,HttpMethod.PUT,null,null);
+		makeApiCall(url,HttpMethod.PUT,lastJsonExtractionDate,null);
 	}
 
-	public LastJsonExtractionDate getLastExtractionDate(String questionnaireModelId, Mode mode) throws KraftwerkException {
-		String url = String.format("%s/extractions/json?collectionInstrumentId=%s",
-				configProperties.getGenesisUrl(), questionnaireModelId);
+	public LastJsonExtractionDate getLastExtractionDate(String collectionInstrumentId, Mode mode) throws KraftwerkException {
+		String url = String.format("%s/collection-instruments/%s/extractions/json/last",
+				configProperties.getGenesisUrl(), collectionInstrumentId);
 		if (mode != null) {
-			url += "&mode=" + mode;
+			url += "?mode=" + mode;
 		}
 		ResponseEntity<LastJsonExtractionDate> response = makeApiCall(url,HttpMethod.GET,null,LastJsonExtractionDate.class);
 		return response.getBody();

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/configuration/TimeConfiguration.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/configuration/TimeConfiguration.java
@@ -1,0 +1,16 @@
+package fr.insee.kraftwerk.api.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfiguration {
+
+    @Bean
+    public Clock clock(){
+        return Clock.systemUTC();
+    }
+
+}

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/dto/InterrogationBatchResponse.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/dto/InterrogationBatchResponse.java
@@ -1,0 +1,15 @@
+package fr.insee.kraftwerk.api.dto;
+
+import fr.insee.kraftwerk.core.data.model.InterrogationId;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+public class InterrogationBatchResponse {
+
+    private List<InterrogationId> interrogationIds;
+    private Instant nextSince;
+
+}

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/dto/LastJsonExtractionDate.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/dto/LastJsonExtractionDate.java
@@ -1,12 +1,12 @@
 package fr.insee.kraftwerk.api.dto;
 
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
+import java.time.Instant;
+
+@Data
 @NoArgsConstructor
 public class LastJsonExtractionDate {
-    private String lastExtractionDate;
+    private Instant lastExtractionDate;
 }

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/AbstractMainProcessingGenesis.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/AbstractMainProcessingGenesis.java
@@ -129,7 +129,7 @@ public abstract class AbstractMainProcessingGenesis {
         int nbPartitions = listIds.size();
         int indexPartition = 1;
         for (List<InterrogationId> listId : listIds) {
-            List<SurveyUnitUpdateLatest> suLatest = client.getResponses(questionnaireModelId, listId);
+            List<SurveyUnitUpdateLatest> suLatest = client.getResponses(questionnaireModelId, listId,null);
             log.info("Number of documents retrieved from database : {}, partition {}/{}", suLatest.size(), indexPartition, nbPartitions);
             vtlBindings = new VtlBindings();
             if (dataMode != null){

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisNew.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisNew.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.insee.kraftwerk.api.client.GenesisClient;
 import fr.insee.kraftwerk.api.configuration.ConfigProperties;
+import fr.insee.kraftwerk.api.dto.InterrogationBatchResponse;
 import fr.insee.kraftwerk.api.dto.LastJsonExtractionDate;
 import fr.insee.kraftwerk.core.data.model.InterrogationId;
 import fr.insee.kraftwerk.core.data.model.Mode;
@@ -28,6 +29,7 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -84,15 +86,30 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
     In this method we write at the end of every batch, not at the end of all batch
     This method can do differential extraction (all data since last extraction) otherwise all data since january 1st 2025
      */
-    public void runMainJson(String collectionInstrumentId, int batchSize, Mode dataMode, LocalDateTime since) throws KraftwerkException, IOException {
-        log.info("Export json for collectionInstrumentId {}", collectionInstrumentId);
+    public boolean runMainJson(String collectionInstrumentId, int batchSize, Mode dataMode, Instant since) throws KraftwerkException, IOException {
 
-        LocalDateTime beginDate = resolveBeginDate(collectionInstrumentId, dataMode, since);
+        long start = System.currentTimeMillis();
 
-        List<InterrogationId> ids =
-                fetchInterrogationIds(collectionInstrumentId, beginDate);
+        Instant beginDate = resolveBeginDate(collectionInstrumentId, dataMode, since);
+
+        InterrogationBatchResponse batchResponse =
+                fetchInterrogationBatch(collectionInstrumentId, beginDate);
+
+        List<InterrogationId> ids = batchResponse.getInterrogationIds();
+
+        if (ids.isEmpty()) {
+            log.info("No interrogation to process collectionInstrumentId={} since={}", collectionInstrumentId, beginDate);
+            return false;
+        }
+
+        log.info("Processing {} interrogationIds for collectionInstrumentId={}", ids.size(), collectionInstrumentId);
+        if (batchResponse.getNextSince()!=null) kraftwerkExecutionContext.setRecordedBefore(batchResponse.getNextSince());
 
         runMainJsonInternal(collectionInstrumentId, batchSize, dataMode, ids, true);
+
+        long duration = System.currentTimeMillis() - start;
+        log.info("Processed {} interrogationId for collectionInstrumentId={} in {} ms", ids.size(), collectionInstrumentId, duration);
+        return true;
     }
 
     public void runMainJsonReplay(String collectionInstrumentId,
@@ -142,7 +159,7 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
             jsonGenerator.writeStartArray();
 
             for (List<InterrogationId> listId : partitions) {
-                List<SurveyUnitUpdateLatest> suLatest = client.getResponses(id, listId);
+                List<SurveyUnitUpdateLatest> suLatest = client.getResponses(id, listId, kraftwerkExecutionContext.getRecordedBefore());
                 log.info("Number of documents retrieved from database : {}, partition {}/{}", suLatest.size(), indexPartition, nbPartitions);
                 vtlBindings = new VtlBindings();
                 // if one mode is specified we filter to keep data of that mode only
@@ -168,7 +185,9 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
         writeErrors();
 
         if (updateLastExtraction) {
-            client.saveDateExtraction(id, dataMode);
+            LastJsonExtractionDate lastJsonExtractionDate = new LastJsonExtractionDate();
+            lastJsonExtractionDate.setLastExtractionDate(kraftwerkExecutionContext.getRecordedBefore());
+            client.saveDateExtraction(id, dataMode, lastJsonExtractionDate);
         }
 
         SqlUtils.deleteDatabaseFile(databasePath);
@@ -205,9 +224,9 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
      * 2. The last extraction date from Genesis,
      * 3. Or null if nothing is found (meaning: extract all data).
      */
-    private LocalDateTime resolveBeginDate(String questionnaireModelId,
+    private Instant resolveBeginDate(String questionnaireModelId,
                                            Mode dataMode,
-                                           @Nullable LocalDateTime since) {
+                                           @Nullable Instant since) {
         // 1. Explicit date provided
         if (since != null) {
             log.info("Using provided extraction start date {} for questionnaire {}", since, questionnaireModelId);
@@ -220,9 +239,7 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
 
         try {
             LastJsonExtractionDate lastExtractDate = client.getLastExtractionDate(questionnaireModelId, dataMode);
-            LocalDateTime beginDate = LocalDateTime.parse(lastExtractDate.getLastExtractionDate());
-            // Overlap of 10s to avoid data loss between differential exports
-            beginDate = beginDate.minusSeconds(10);
+            Instant beginDate = lastExtractDate.getLastExtractionDate();
 
             log.info("Extracting data between {} and now for questionnaire {}", beginDate, questionnaireModelId);
             return beginDate;
@@ -233,13 +250,13 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
         }
     }
 
-    private List<InterrogationId> fetchInterrogationIds(String questionnaireModelId,
-                                                        @Nullable LocalDateTime beginDate)
+    private InterrogationBatchResponse fetchInterrogationBatch(String questionnaireModelId,
+                                                             @Nullable Instant beginDate)
             throws KraftwerkException {
         if (beginDate != null) {
-            return client.getInterrogationIdsFromDate(questionnaireModelId, beginDate);
+            return client.getInterrogationBatchSince(questionnaireModelId, beginDate);
         }
-        return client.getInterrogationIds(questionnaireModelId);
+        return client.getInterrogationBatchAll(questionnaireModelId);
     }
 
     private List<InterrogationId> fetchInterrogationIdsWithRecordDateBetween(

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisNew.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisNew.java
@@ -102,6 +102,7 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
 
         if (ids.isEmpty()) {
             log.info("No interrogation to process collectionInstrumentId={} since={}", collectionInstrumentId, beginDate);
+            runMainJsonInternal(collectionInstrumentId, batchSize, dataMode, ids, false);
             return false;
         }
 

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisNew.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisNew.java
@@ -247,7 +247,7 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
                     try {
                         log.info("DEBUG processing interrogationId={}", interrogationId.getId());
 
-                        suLatest = client.getResponses(id, List.of(interrogationId));
+                        suLatest = client.getResponses(id, List.of(interrogationId), Instant.now());
 
                         if (suLatest == null || suLatest.isEmpty()) {
                             log.warn("DEBUG EMPTY interrogationId={} -> no SurveyUnit found", interrogationId);
@@ -391,7 +391,7 @@ public class MainProcessingGenesisNew extends AbstractMainProcessingGenesis{
             throw new KraftwerkException(400, "endDate must be after startDate");
         }
 
-        return client.getInterrogationIdsBetweenDates(collectionInstrumentId, start, end);
+        return client.getInterrogationBatchBetween(collectionInstrumentId, start, end).getInterrogationIds();
     }
 
     private void moveTempFile(String filename, Path tmpOutputFile) throws KraftwerkException {

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/BatchExportService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/BatchExportService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -332,7 +333,7 @@ public class BatchExportService extends KraftwerkService {
             String collectionInstrumentId,
             Mode dataMode,
             int batchSize,
-            LocalDateTime since,
+            Instant since,
             boolean addStates
     ) {
         FileUtilsInterface fileUtilsInterface = getFileUtilsInterface();

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/KraftwerkService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/KraftwerkService.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 @RestController
 @ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Success"),
+		@ApiResponse(responseCode = "204", description = "No content"),
 		@ApiResponse(responseCode = "400", description = "Bad Request"),
 		@ApiResponse(responseCode = "413", description = "Request Entity Too Large"),
 		@ApiResponse(responseCode = "404", description = "Not Found"),

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
@@ -34,6 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
@@ -38,6 +38,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -52,13 +54,15 @@ public class MainService extends KraftwerkService {
     VaultConfig vaultConfig;
     boolean useMinio;
     InMemoryExportJobStore exportJobStore;
+    private final Clock clock;
 
 
     @Autowired
-    public MainService(MainAsyncService mainAsyncService, ConfigProperties configProperties, MinioConfig minioConfig, VaultConfig vaultConfig, Environment env, InMemoryExportJobStore exportJobStore) {
+    public MainService(MainAsyncService mainAsyncService, ConfigProperties configProperties, MinioConfig minioConfig, VaultConfig vaultConfig, Environment env, InMemoryExportJobStore exportJobStore, Clock clock) {
         super(configProperties, minioConfig);
         this.mainAsyncService = mainAsyncService;
         this.configProperties = configProperties;
+        this.clock = clock;
         this.minioConfig = minioConfig;
         this.vaultConfig = vaultConfig;
         this.exportJobStore = exportJobStore;
@@ -265,9 +269,10 @@ public class MainService extends KraftwerkService {
             @Parameter(description = "${param.collectionInstrumentId}", required = true, example = INDIRECTORY_EXAMPLE) @RequestParam String collectionInstrumentId,
             @Parameter(description = "${param.dataMode}") @RequestParam(required = false) Mode dataMode,
             @Parameter(description = "${param.batchSize}") @RequestParam(value = "batchSize", defaultValue = "1000") int batchSize,
-            @Parameter(description = "Extract since") @RequestParam(value = "sinceDate",required = false) LocalDateTime since,
+            @Parameter(description = "Extract since") @RequestParam(value = "sinceDate",required = false) Instant since,
             @Parameter(description = "${param.addStates}") @RequestParam(value = "addStates", defaultValue = "false") boolean addStates
     ){
+        log.info("START jsonExtraction collectionInstrumentId={} batchSize={} since={}", collectionInstrumentId, batchSize, since);
         FileUtilsInterface fileUtilsInterface = getFileUtilsInterface();
         boolean withDDI = true;
         boolean withEncryption = false;
@@ -279,8 +284,11 @@ public class MainService extends KraftwerkService {
                 addStates
         );
         try {
-            mpGenesis.runMainJson(collectionInstrumentId, batchSize, dataMode, since);
-            log.info("Data extracted");
+            boolean hasProcessed = mpGenesis.runMainJson(collectionInstrumentId, batchSize, dataMode, since);
+            log.info("END jsonExtraction collectionInstrumentId={} status={}", collectionInstrumentId, hasProcessed ? "PROCESSED" : "NO_DATA");
+            if (!hasProcessed) {
+                return ResponseEntity.noContent().build();
+            }
 		} catch (KraftwerkException e) {
 			return ResponseEntity.status(e.getStatus()).body(e.getMessage());
 		} catch (IOException e) {

--- a/kraftwerk-api/src/main/resources/i18n/messages_en.properties
+++ b/kraftwerk-api/src/main/resources/i18n/messages_en.properties
@@ -49,6 +49,7 @@ description.archive=Archive input files (in Directory)
 param.inDirectory=Directory containing the input files
 param.campaignId=Survey campaign id
 param.questionnaireId=Identifier of the questionnaire template used by the survey
+param.collectionInstrumentId=Identifier of the questionnaire template used by the survey
 param.batchSize=Number of interrogations processed per batch by Kraftwerk
 param.archiveAtEnd=True if you want to archive, default = false
 param.withAllReportingData=True if you want to have reportingData without questionnaire, default = true

--- a/kraftwerk-api/src/main/resources/i18n/messages_fr.properties
+++ b/kraftwerk-api/src/main/resources/i18n/messages_fr.properties
@@ -52,6 +52,8 @@ description.archive=Archivage dans un dossier spécifique des données en entrée
 param.inDirectory=Nom ou chemin vers le dossier contenant les fichiers d'entrée
 param.campaignId=Identifiant de l'enquête
 param.questionnaireModelId=Identifiant du modèle de questionnaire utilisé par l'enquête
+param.collectionInstrumentId=Identifiant du modèle de questionnaire utilisé par l'enquête
+
 param.batchSize=Nombre d'interrogations traitées par lot par Kraftwerk
 param.archiveAtEnd=Booléen, true si on souhaite archiver à la fin du traitement. Par défaut, la valeur est false (pas d'archivage)
 param.withAllReportingData=Booléen, true si on souhaite récupérer les lignes de reportingData non associées à un questionnaire (non répondant). Par défaut, la valeur est true.

--- a/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/ArgsCheckerTest.java
+++ b/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/ArgsCheckerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.*;
@@ -190,11 +191,11 @@ class ArgsCheckerTest {
         ArgsChecker checker = ArgsChecker.builder()
                 .argServiceName("JSON")
                 .argQuestionnaireId("questionnaire-123")
-                .argSince("2024-01-15T10:30:00")
+                .argSince("2024-01-15T10:30:00Z")
                 .build();
 
         assertThatNoException().isThrownBy(checker::checkArgs);
-        assertThat(checker.getSince()).isEqualTo(LocalDateTime.of(2024, 1, 15, 10, 30, 0));
+        assertThat(checker.getSince()).isEqualTo(Instant.parse("2024-01-15T10:30:00Z"));
     }
 
     @Test

--- a/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/KraftwerkBatchTest.java
+++ b/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/KraftwerkBatchTest.java
@@ -334,7 +334,7 @@ class KraftwerkBatchTest {
         when(args.getOptionValues("service")).thenReturn(List.of("JSON"));
         when(args.getOptionValues("questionnaireId")).thenReturn(List.of("TESTCAMPAIGN2"));
         when(args.getOptionValues("with-ddi")).thenReturn(List.of("true"));
-        when(args.getOptionValues("extract-json-since")).thenReturn(List.of("2022-12-01T12:00:00"));
+        when(args.getOptionValues("extract-json-since")).thenReturn(List.of("2022-12-01T12:00:00Z"));
 
         kraftwerkBatch.run(args);
 

--- a/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/KraftwerkBatchTest.java
+++ b/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/KraftwerkBatchTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.core.env.Environment;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 
@@ -341,7 +342,7 @@ class KraftwerkBatchTest {
                 any(),
                 any(),
                 eq(KraftwerkBatch.DEFAULT_BATCH_SIZE),
-                eq(LocalDateTime.of(2022, 12, 1, 12, 0 ,0)),
+                eq(LocalDateTime.of(2022, 12, 1, 12, 0 ,0).toInstant(ZoneOffset.UTC)),
                 eq(false)
         );
         verifyNoInteractions(reportingDataService);

--- a/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisLegacyTest.java
+++ b/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/process/MainProcessingGenesisLegacyTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,7 +74,7 @@ class MainProcessingGenesisLegacyTest {
             }
 
             @Override
-            public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds) {
+            public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds, Instant recordedBefore) {
                 SurveyUnitUpdateLatest surveyUnitUpdateLatest = new SurveyUnitUpdateLatest();
                 surveyUnitUpdateLatest.setCollectedVariables(new ArrayList<>());
                 surveyUnitUpdateLatest.setExternalVariables(new ArrayList<>());

--- a/kraftwerk-core/src/main/java/fr/insee/kraftwerk/core/utils/KraftwerkExecutionContext.java
+++ b/kraftwerk-core/src/main/java/fr/insee/kraftwerk/core/utils/KraftwerkExecutionContext.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -38,6 +39,8 @@ public class KraftwerkExecutionContext {
     private boolean addStates;
 
     private Path outDirectory;
+
+    private Instant recordedBefore;
 
     public KraftwerkExecutionContext(
             String inDirectoryParam,

--- a/kraftwerk-encryption-tests/src/test/java/stubs/GenesisClientStub.java
+++ b/kraftwerk-encryption-tests/src/test/java/stubs/GenesisClientStub.java
@@ -10,6 +10,7 @@ import fr.insee.kraftwerk.core.exceptions.KraftwerkException;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,12 +84,13 @@ public class GenesisClientStub extends GenesisClient {
     }
 
     @Override
-    public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds) {
+    public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds, Instant recordedBefore) {
         List<SurveyUnitUpdateLatest> list = new ArrayList<>();
 
         List<SurveyUnitUpdateLatest> mongoFiltered1 = mongoStub.stream()
                 .filter(
                         surveyUnitUpdateLatest -> surveyUnitUpdateLatest.getCollectionInstrumentId().equals(collectionInstrumentId)
+
                 ).toList();
 
         Set<SurveyUnitUpdateLatest> mongoFiltered2 = new HashSet<>();

--- a/kraftwerk-functional-tests/src/test/java/stubs/GenesisClientStub.java
+++ b/kraftwerk-functional-tests/src/test/java/stubs/GenesisClientStub.java
@@ -10,6 +10,7 @@ import fr.insee.kraftwerk.core.exceptions.KraftwerkException;
 import lombok.Getter;
 import lombok.SneakyThrows;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -81,7 +82,7 @@ public class GenesisClientStub extends GenesisClient {
     }
 
     @Override
-    public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds) {
+    public List<SurveyUnitUpdateLatest> getResponses(String collectionInstrumentId, List<InterrogationId> interrogationIds, Instant recordedBefore) {
         List<SurveyUnitUpdateLatest> list = new ArrayList<>();
 
         List<SurveyUnitUpdateLatest> mongoFiltered1 = mongoStub.stream()


### PR DESCRIPTION
We previously stored the timestamp at the end of the extraction process, several minutes after retrieving the IDs to be processed. As a result, any records created after the interrogationIds were listed but before the process completed were not included in the differential JSON output.

To address this issue, we now capture the most recent timestamp (recordDate) at the moment the interrogationIds are retrieved. This timestamp is then used as the reference point for the next differential extraction.