### PR TITLE
ajouter le with encryption option to json export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.16.0 [TODO]
+### Changed
+- Add `withEncryption` support for JSON export endpoints (`/json` and `/json/replay`)
+
 ## 3.15.3 [2026-04-29]
 ### Added
 - Display export file path in batch responses

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/batch/KraftwerkBatch.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/batch/KraftwerkBatch.java
@@ -193,6 +193,7 @@ public class KraftwerkBatch implements ApplicationRunner {
                         argsChecker.getMode(),
                         argsChecker.getBatchSize() == null ? DEFAULT_BATCH_SIZE : argsChecker.getBatchSize(),
                         argsChecker.getSince(),
+                        argsChecker.isWithEncryption(),
                         argsChecker.isAddStates()
                 );
             }

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/client/GenesisClient.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/client/GenesisClient.java
@@ -24,7 +24,6 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/BatchExportService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/BatchExportService.java
@@ -334,11 +334,11 @@ public class BatchExportService extends KraftwerkService {
             Mode dataMode,
             int batchSize,
             Instant since,
+            boolean withEncryption,
             boolean addStates
     ) {
         FileUtilsInterface fileUtilsInterface = getFileUtilsInterface();
         boolean withDDI = true;
-        boolean withEncryption = false;
 
         MainProcessingGenesisNew mpGenesis = getMainProcessingGenesisByQuestionnaire(
                 withDDI,

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
@@ -43,7 +43,6 @@ import org.springframework.web.bind.annotation.RestController;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @RestController
@@ -58,14 +57,17 @@ public class MainService extends KraftwerkService {
     boolean useMinio;
     InMemoryExportJobStore exportJobStore;
     private final Clock clock;
+    private final OutputZipService outputZipService;
+
 
 
     @Autowired
-    public MainService(MainAsyncService mainAsyncService, ConfigProperties configProperties, MinioConfig minioConfig, VaultConfig vaultConfig, Environment env, InMemoryExportJobStore exportJobStore, Clock clock) {
+    public MainService(MainAsyncService mainAsyncService, ConfigProperties configProperties, MinioConfig minioConfig, VaultConfig vaultConfig, Environment env, InMemoryExportJobStore exportJobStore, Clock clock, OutputZipService outputZipService) {
         super(configProperties, minioConfig);
         this.mainAsyncService = mainAsyncService;
         this.configProperties = configProperties;
         this.clock = clock;
+        this.outputZipService = outputZipService;
         this.minioConfig = minioConfig;
         this.vaultConfig = vaultConfig;
         this.exportJobStore = exportJobStore;
@@ -273,12 +275,13 @@ public class MainService extends KraftwerkService {
             @Parameter(description = "${param.dataMode}") @RequestParam(required = false) Mode dataMode,
             @Parameter(description = "${param.batchSize}") @RequestParam(value = "batchSize", defaultValue = "1000") int batchSize,
             @Parameter(description = "Extract since") @RequestParam(value = "sinceDate",required = false) Instant since,
+            @Parameter(description = "${param.withEncryption}")
+            @RequestParam(value = "withEncryption", defaultValue = "false") boolean withEncryption,
             @Parameter(description = "${param.addStates}") @RequestParam(value = "addStates", defaultValue = "false") boolean addStates
     ){
         log.info("START jsonExtraction collectionInstrumentId={} batchSize={} since={}", collectionInstrumentId, batchSize, since);
         FileUtilsInterface fileUtilsInterface = getFileUtilsInterface();
         boolean withDDI = true;
-        boolean withEncryption = false;
 
         MainProcessingGenesisNew mpGenesis = getMainProcessingGenesisByQuestionnaire(
                 withDDI,
@@ -292,6 +295,10 @@ public class MainService extends KraftwerkService {
             if (!hasProcessed) {
                 return ResponseEntity.noContent().build();
             }
+            outputZipService.encryptAndArchiveOutputs(
+                    mpGenesis.getKraftwerkExecutionContext(),
+                    fileUtilsInterface
+            );
 		} catch (KraftwerkException e) {
 			return ResponseEntity.status(e.getStatus()).body(e.getMessage());
 		} catch (IOException e) {
@@ -318,13 +325,14 @@ public class MainService extends KraftwerkService {
                     schema = @Schema(type = "string", format = "date-time", example = "2026-02-02T00:00:00Z")
             )
             @RequestParam(value = "untilDate",required = false) Instant end,
+            @Parameter(description = "${param.withEncryption}")
+            @RequestParam(value = "withEncryption", defaultValue = "false") boolean withEncryption,
             @Parameter(description = "${param.addStates}")
             @RequestParam(value = "addStates", defaultValue = "false")
             boolean addStates
     ){
         FileUtilsInterface fileUtilsInterface = getFileUtilsInterface();
         boolean withDDI = true;
-        boolean withEncryption = false;
 
         MainProcessingGenesisNew mpGenesis = getMainProcessingGenesisByQuestionnaire(
                 withDDI,
@@ -334,6 +342,10 @@ public class MainService extends KraftwerkService {
         );
         try {
             mpGenesis.runMainJsonReplay(collectionInstrumentId, batchSize, dataMode, start, end);
+            outputZipService.encryptAndArchiveOutputs(
+                    mpGenesis.getKraftwerkExecutionContext(),
+                    fileUtilsInterface
+            );
             log.info("Data extracted");
         } catch (KraftwerkException e) {
             return ResponseEntity.status(e.getStatus()).body(e.getMessage());

--- a/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
+++ b/kraftwerk-api/src/main/java/fr/insee/kraftwerk/api/services/MainService.java
@@ -360,13 +360,12 @@ public class MainService extends KraftwerkService {
             @RequestParam String collectionInstrumentId,
             @RequestParam(required = false) Mode dataMode,
             @RequestParam(value = "batchSize", defaultValue = "1000") int batchSize,
+            @RequestParam(value = "withEncryption", defaultValue = "false") boolean withEncryption,
             @RequestParam(value = "addStates", defaultValue = "false") boolean addStates,
             @RequestBody DebugJsonExportDto debugJsonExportDto
     ) {
         FileUtilsInterface fileUtilsInterface = getFileUtilsInterface();
         boolean withDDI = true;
-        boolean withEncryption = false;
-
         MainProcessingGenesisNew mpGenesis = getMainProcessingGenesisByQuestionnaire(withDDI, withEncryption, fileUtilsInterface, addStates);
 
         try {
@@ -379,6 +378,10 @@ public class MainService extends KraftwerkService {
                     batchSize,
                     dataMode,
                     debugJsonExportDto.getInterrogationIds()
+            );
+            outputZipService.encryptAndArchiveOutputs(
+                    mpGenesis.getKraftwerkExecutionContext(),
+                    fileUtilsInterface
             );
 
             return ResponseEntity.ok(result);

--- a/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/KraftwerkBatchTest.java
+++ b/kraftwerk-api/src/test/java/fr/insee/kraftwerk/api/batch/KraftwerkBatchTest.java
@@ -287,6 +287,7 @@ class KraftwerkBatchTest {
                 any(),
                 eq(KraftwerkBatch.DEFAULT_BATCH_SIZE),
                 eq(null),
+                eq(false),
                 eq(true)
         );
         verifyNoInteractions(reportingDataService);
@@ -309,6 +310,7 @@ class KraftwerkBatchTest {
                 any(),
                 eq(100),
                 eq(null),
+                eq(false),
                 eq(true)
         );
         verifyNoInteractions(reportingDataService);
@@ -331,6 +333,7 @@ class KraftwerkBatchTest {
                 eq(Mode.WEB),
                 eq(KraftwerkBatch.DEFAULT_BATCH_SIZE),
                 eq(null),
+                eq(false),
                 eq(true)
         );
         verifyNoInteractions(reportingDataService);
@@ -352,6 +355,7 @@ class KraftwerkBatchTest {
                 any(),
                 eq(KraftwerkBatch.DEFAULT_BATCH_SIZE),
                 eq(LocalDateTime.of(2022, 12, 1, 12, 0 ,0).toInstant(ZoneOffset.UTC)),
+                eq(false),
                 eq(false)
         );
         verifyNoInteractions(reportingDataService);


### PR DESCRIPTION
Added the withEncryption parameter to /json and /json/replay endpoints.

withEncryption=true → output is archived and encrypted (.enc)
withEncryption=false → output remains a standard .json file