### PR TITLE
Setting max RAM percentage to 75% of memory limit on the pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM gitlab-registry.insee.fr/kubernetes/images/run/java:25.0.1_8-jre-rootless
 ARG VERSION_APPLICATION
 COPY --chown=$JAVA_USER:$JAVA_USER Kraftwerk/kraftwerk-api/target/kraftwerk-api-$VERSION_APPLICATION.jar kraftwerk.jar
 
-ENV JAVA_TOOL_OPTIONS \
-    -XX:+UseZGC \
-    -Xmx4g
+ENV JAVA_TOOL_OPTIONS="-XX:+UseZGC -XX:MaxRAMPercentage=75"
 
 EXPOSE 8080
 


### PR DESCRIPTION
Using a fixed heap size is unreliable in a containerized environment. We replace -Xmx4g with -XX:MaxRAMPercentage=75 so the JVM heap scales dynamically with the memory limit set on the pod.